### PR TITLE
Inline type definitions to not depend on Zod

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Expo module for BlueConic SDK React Native
 To install the package use your prefered package manager:
 
 ```bash
-npm install @allboatsrise/expo-blueconic @blueconic/blueconic-react-native zod
+npm install @allboatsrise/expo-blueconic @blueconic/blueconic-react-native
 ```
 or
 ```bash
-yarn add @allboatsrise/expo-blueconic @blueconic/blueconic-react-native zod
+yarn add @allboatsrise/expo-blueconic @blueconic/blueconic-react-native
 ```
 
 ## Plugin setup
@@ -25,7 +25,7 @@ Add package to `plugins` in `app.js`/`app.config.js`.
     [
       "@allboatsrise/expo-blueconic", {
         "serverUrl": "<< BLUECONIC_SERVER_URL >>",
-        "debug": false,
+        "debug": false, // optional
         "androidBlueConicSdkVersion": "5.1.0", // optional
         "iosBlueConicClientPodVersion": "3.2.0" // optional
       }

--- a/package.json
+++ b/package.json
@@ -38,16 +38,14 @@
     "@expo/config-plugins": "^8.0.4",
     "@types/react": "~18.2.79",
     "expo": "^51.0.0",
-    "expo-module-scripts": "^3.5.1",
-    "zod": "~3.15.0"
+    "expo-module-scripts": "^3.5.1"
   },
   "peerDependencies": {
     "@blueconic/blueconic-react-native": "^3.1.0",
     "@expo/config-plugins": ">=8.0.0",
     "expo": ">=51.0.0",
     "react": "*",
-    "react-native": "*",
-    "zod": "^3.15.0"
+    "react-native": "*"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,31 +1,22 @@
-import { z } from 'zod';
-
-export type BlueConicSdkPluginOptions = z.infer<typeof BlueConicSdkPluginOptionsSchema>
-
-export const BlueConicSdkPluginOptionsSchema = z.object({
+export type BlueConicSdkPluginProps = {
+  packageName: string,
+  packageVersion: string,
 
   /** BlueConic server url */
-  serverUrl: z.string({required_error: 'Must provide server url. For example "https://example.blueconic.net"'}).url({message: 'Invalid server url.'}),
+  serverUrl: string,
   
   /** Set to true in order to receive debug logs from the BlueConic SDK */
-  debug: z.boolean({required_error: 'Must provide app id.'}).optional(),
+  debug?: boolean,
 
   /**
-   * BlueConic SDK version to use on Android.
+   * BlueConic SDK version to use on Android. For example: '5.1.0'
    * @see https://support.blueconic.com/hc/en-us/articles/20095976036251-BlueConic-SDK-for-Android-Release-Notes
    */
-  androidBlueConicSdkVersion: z.string().optional().default('5.1.0'),
+  androidBlueConicSdkVersion?: string,
 
   /**
-   * Version of `BlueConicClient` Cocoa pod to use.
+   * Version of `BlueConicClient` Cocoa pod to use. For example: '3.2.0'
    * @see https://support.blueconic.com/hc/en-us/articles/20151716578971-BlueConic-SDK-for-iOS-Release-Notes
    */
-  iosBlueConicClientPodVersion: z.string().optional().default('3.2.0'),
-  
-}, {required_error: 'Must configure plugin options.'})
-
-
-export type BlueConicSdkPluginProps = BlueConicSdkPluginOptions & {
-  packageName: string
-  packageVersion: string
+  iosBlueConicClientPodVersion?: string,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7558,8 +7558,3 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zod@~3.15.0:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.15.1.tgz#9e404cd8002ccffb03baa94cff2e1638ed49d82f"
-  integrity sha512-WAdjcoOxa4S9oc/u7fTbC3CC7uVqptLLU0LKqS8RDBOrCXp2t5avM8BUfgNVZJymGWAx6SEUYxWPPoYuQ5rgwQ==


### PR DESCRIPTION
Hi there! Awesome plugin you have, I learned a lot from reading the code :)

I saw that Zod is only used to infer a type definition, so I used my TS skills to inline it. If you paste it into https://transform.tools/typescript-to-zod you will see it generates the same output as Zod did.
This means that projects, such as the ones we use at Enrise, that do not use Zod do not need to pull that dependency in for just those types.